### PR TITLE
isolate checkpointing within model except random number states

### DIFF
--- a/include/lbann/io/persist.hpp
+++ b/include/lbann/io/persist.hpp
@@ -49,7 +49,6 @@ enum class callback_type {
 
 class persist {
  protected:
-  int m_rank;
   uint64_t m_bytes;
   int m_model_fd;
   int m_train_fd;
@@ -64,10 +63,6 @@ class persist {
  public:
   persist();
   ~persist() {};
-
-  int get_rank() const {
-    return m_rank;
-  }
 
   callback_type get_cb_type() const {
     return ckpt_type;

--- a/include/lbann/layers/io/input/generic_input_layer.hpp
+++ b/include/lbann/layers/io/input/generic_input_layer.hpp
@@ -636,7 +636,7 @@ class generic_input_layer : public io_layer {
       if ((it != this->m_data_readers.end()) && it->second) {
         (it->second)->save_to_checkpoint_shared(p, "data_reader_testing");
       }
-      if (p.get_rank() == 0) {
+      if (m_comm->am_model_master()) {
         p.write_uint64(persist_type::train, "reader_train_processed",
                        (uint64_t) m_training_dataset.get_num_samples_processed());
         p.write_uint64(persist_type::train, "reader_train_total",
@@ -650,7 +650,7 @@ class generic_input_layer : public io_layer {
       }
     }
     if(p.get_cb_type() == callback_type::validation || p.get_cb_type() == callback_type::batch){
-      if (p.get_rank() == 0) {
+      if (m_comm->am_model_master()) {
         p.write_uint64(persist_type::validate, "reader_validate_processed",
                        (uint64_t) m_validation_dataset.get_num_samples_processed());
         p.write_uint64(persist_type::validate, "reader_validate_total",
@@ -691,7 +691,7 @@ class generic_input_layer : public io_layer {
     // rank 0 reads the file
     dataset_header header;
     // Assume we are loading from a epoch end checkpoint
-    if (p.get_rank() == 0) {
+    if (m_comm->am_model_master()) {
       p.read_uint64(persist_type::train, "reader_train_processed",    &header.train_proc);
       p.read_uint64(persist_type::train, "reader_train_total",        &header.train_total);
       p.read_uint64(persist_type::train, "reader_test_processed",     &header.test_proc);

--- a/include/lbann/utils/random.hpp
+++ b/include/lbann/utils/random.hpp
@@ -156,8 +156,8 @@ void bernoulli_fill_procdet(AbsDistMat& mat, El::Int m, El::Int n, double p = 0.
 void uniform_fill_procdet(AbsDistMat& mat, El::Int m, El::Int n,
                           DataType center = 0.0f, DataType radius = 1.0f);
 
-bool save_rng_to_checkpoint_shared(persist& p);
-bool load_rng_from_checkpoint_shared(persist& p);
+bool save_rng_to_checkpoint_shared(persist& p, const lbann_comm* comm);
+bool load_rng_from_checkpoint_shared(persist& p, const lbann_comm* comm);
 
 template<typename DistType,typename DType=DataType>
 class rng {

--- a/src/data_readers/data_reader.cpp
+++ b/src/data_readers/data_reader.cpp
@@ -381,7 +381,7 @@ void generic_data_reader::use_unused_index_set() {
 /** \brief Given directory to store checkpoint files, write state to file and add to number of bytes written */
 bool generic_data_reader::save_to_checkpoint_shared(persist& p, const char *name) {
   // rank 0 writes the training state file
-  if (p.get_rank() == 0) {
+  if (m_comm->am_model_master()) {
     pack_scalars(p,name);
   }
   return true;
@@ -391,19 +391,16 @@ bool generic_data_reader::save_to_checkpoint_shared(persist& p, const char *name
 bool lbann::generic_data_reader::load_from_checkpoint_shared(persist& p, const char *name) {
   // rank 0 reads the training state file
   struct packing_header header;
-  if (p.get_rank() == 0) {
+  if (m_comm->am_model_master()) {
     unpack_scalars(p,&header,name);
   }
-  MPI_Bcast(&header, sizeof(header), MPI_BYTE, 0, MPI_COMM_WORLD);
+  m_comm->model_broadcast(0, header);
   unpack_header(header);
 
-  m_shuffled_indices.resize(header.data_size);
+  m_comm->model_broadcast(0, m_shuffled_indices);
 
-  if (header.data_size > 0ull) {
-    MPI_Bcast(&m_shuffled_indices[0], header.data_size, MPI_INT, 0, MPI_COMM_WORLD);
-  }
   // Adjust current position to deal with fact that it was just loaded to all ranks from rank 0 (differs by rank #)
-  m_current_pos += p.get_rank();
+  m_current_pos += m_comm->get_rank_in_model();
   return true;
 }
 

--- a/src/io/persist.cpp
+++ b/src/io/persist.cpp
@@ -213,9 +213,6 @@ bool lbann::persist::read_rank_distmat(persist_type type, const char *name, AbsD
  ****************************************************/
 
 lbann::persist::persist() {
-  // lookup our MPI rank
-  MPI_Comm_rank(MPI_COMM_WORLD, &m_rank);
-
   // initialize number of bytes written
   m_bytes = 0;
 
@@ -233,7 +230,6 @@ void lbann::persist::open_checkpoint(const char *dir) {
   strcpy(m_checkpoint_dir, dir);
 
   // open the file for writing
-  //else if(!per_rank && m_rank == 0) {
    sprintf(m_model_filename, "%s/model", dir);
 
   // define filename for train state

--- a/src/optimizers/adam.cpp
+++ b/src/optimizers/adam.cpp
@@ -238,7 +238,7 @@ void adam::set_states_on_device() {
 bool adam::save_to_checkpoint_shared(persist& p, std::string name_prefix) {
   optimizer::save_to_checkpoint_shared(p, name_prefix);
 
-  if (p.get_rank() == 0) {
+  if (m_comm->am_model_master()) {
     pack_scalars(p);
   }
 
@@ -255,11 +255,11 @@ bool adam::save_to_checkpoint_shared(persist& p, std::string name_prefix) {
 bool adam::load_from_checkpoint_shared(persist& p, std::string name_prefix) {
   optimizer::load_from_checkpoint_shared(p, name_prefix);
   struct packing_header header;
-  if (p.get_rank() == 0) {
+  if (m_comm->am_model_master()) {
     unpack_scalars(p, &header);
   }
 
-  MPI_Bcast(&header, sizeof(header), MPI_BYTE, 0, MPI_COMM_WORLD);
+  m_comm->model_broadcast(0, header);
 
   unpack_header(header);
 

--- a/src/optimizers/hypergradient_adam.cpp
+++ b/src/optimizers/hypergradient_adam.cpp
@@ -204,7 +204,7 @@ void hypergradient_adam::step_compute(AbsDistMat& values,
 bool hypergradient_adam::save_to_checkpoint_shared(persist& p, std::string name_prefix) {
   if(p.get_cb_type() == callback_type::batch)
     optimizer::save_to_checkpoint_shared(p,name_prefix);
-  if (p.get_rank() == 0) {
+  if (m_comm->am_model_master()) {
     pack_scalars(p);
   }
  
@@ -225,11 +225,11 @@ bool hypergradient_adam::load_from_checkpoint_shared(persist& p, std::string nam
   if(p.get_cb_type() == callback_type::batch)
     optimizer::load_from_checkpoint_shared(p,name_prefix);
   struct packing_header header;
-  if (p.get_rank() == 0) {
+  if (m_comm->am_model_master()) {
     unpack_scalars(p, &header);
   }
  
-  MPI_Bcast(&header, sizeof(header), MPI_BYTE, 0, MPI_COMM_WORLD);
+  m_comm->model_broadcast(0, header);
 
   unpack_header(header);
 

--- a/src/optimizers/optimizer.cpp
+++ b/src/optimizers/optimizer.cpp
@@ -492,7 +492,7 @@ bool optimizer::save_to_checkpoint_shared(persist& p, std::string m_name) {
 
 bool optimizer::load_from_checkpoint_shared(persist& p, std::string m_name) {
   p.read_datatype(persist_type::train, "learning_rate", &m_learning_rate);
-  MPI_Bcast(&m_learning_rate, 1, MPI_FLOAT, 0, MPI_COMM_WORLD);
+  m_comm->model_broadcast(0, m_learning_rate);
   return true;
 }
 

--- a/src/utils/random.cpp
+++ b/src/utils/random.cpp
@@ -70,7 +70,7 @@ rng_gen& get_data_seq_generator() {
   return ::data_seq_generator;
 }
 
-bool save_rng_to_checkpoint_shared(persist& p){
+bool save_rng_to_checkpoint_shared(persist& p, const lbann_comm* comm) {
   std::string dirname = std::string(p.m_checkpoint_dir) + "/rng_state";
   makedir(dirname.c_str());
   std::string rng_name;
@@ -83,23 +83,31 @@ bool save_rng_to_checkpoint_shared(persist& p){
   std::ofstream rng_EL(rng_name);
   rng_EL << El::Generator();
 #endif
+
+  std::string rank_in_world;
+  if (comm == nullptr) {
+    rank_in_world = std::to_string(El::mpi::Rank(El::mpi::COMM_WORLD));
+  } else {
+    rank_in_world = std::to_string(comm->get_rank_in_world());
+
+  }
 #ifdef _OPENMP 
   #pragma omp parallel private(rng_name) 
   {
-    rng_name = dirname + "/rng_generator_" + std::to_string(p.get_rank()) + "_" + std::to_string(omp_get_thread_num());
+    rng_name = dirname + "/rng_generator_" + rank_in_world + "_" + std::to_string(omp_get_thread_num());
     std::ofstream rng(rng_name);
     rng << ::generator;
-    
-    rng_name = dirname + "/rng_fast_generator_" + std::to_string(p.get_rank()) + "_" + std::to_string(omp_get_thread_num());
+
+    rng_name = dirname + "/rng_fast_generator_" + rank_in_world + "_" + std::to_string(omp_get_thread_num());
     std::ofstream rng_fast(rng_name);
     rng_fast << ::fast_generator;
   }
 #else
-    rng_name = dirname + "/rng_generator_" + std::to_string(p.get_rank();
+    rng_name = dirname + "/rng_generator_" + rank_in_world;
     std::ofstream rng(rng_name);
     rng << ::generator;
 
-    rng_name = dirname + "/rng_fast_generator_" + std::to_string(p.get_rank());
+    rng_name = dirname + "/rng_fast_generator_" + rank_in_world;
     std::ofstream rng_fast(rng_name);
     rng_fast << ::fast_generator;
 #endif
@@ -107,7 +115,7 @@ bool save_rng_to_checkpoint_shared(persist& p){
    return true;
 }
 
-bool load_rng_from_checkpoint_shared(persist& p){
+bool load_rng_from_checkpoint_shared(persist& p, const lbann_comm* comm) {
   
   std::string dirname = std::string(p.m_checkpoint_dir) + "/rng_state";
   std::string rng_name;
@@ -120,23 +128,31 @@ bool load_rng_from_checkpoint_shared(persist& p){
   std::ifstream rng_EL(rng_name);
   rng_EL >> El::Generator();
 #endif
+
+  std::string rank_in_world;
+  if (comm == nullptr) {
+    rank_in_world = std::to_string(El::mpi::Rank(El::mpi::COMM_WORLD));
+  } else {
+    rank_in_world = std::to_string(comm->get_rank_in_world());
+  }
+
  #ifdef _OPENMP 
   #pragma omp parallel private(rng_name)
   {
-    rng_name = dirname + "/rng_generator_" + std::to_string(p.get_rank()) + "_" + std::to_string(omp_get_thread_num());
+    rng_name = dirname + "/rng_generator_" + rank_in_world + "_" + std::to_string(omp_get_thread_num());
     std::ifstream rng(rng_name);
     rng >> ::generator;
-    
-    rng_name = dirname + "/rng_fast_generator_" + std::to_string(p.get_rank()) + "_" + std::to_string(omp_get_thread_num());
+
+    rng_name = dirname + "/rng_fast_generator_" + rank_in_world + "_" + std::to_string(omp_get_thread_num());
     std::ifstream rng_fast(rng_name);
     rng_fast >> ::fast_generator;
    }
 #else
-    rng_name = dirname + "/rng_generator_" + std::to_string(p.get_rank());
+    rng_name = dirname + "/rng_generator_" + rank_in_world;
     std::ifstream rng(rng_name);
     rng >> ::generator;
 
-    rng_name = dirname + "/rng_fast_generator_" + std::to_string(p.get_rank());
+    rng_name = dirname + "/rng_fast_generator_" + rank_in_world;
     std::ifstream rng_fast(rng_name);
     rng_fast >> ::fast_generator;
    }


### PR DESCRIPTION
- use lbann_comm wrapper for MPI_Bcast calls
- use the model communicator for model state checkpointing
- change root rank checking with model root checking
- Separate rank info from persist